### PR TITLE
Latest updates from Atlas machine

### DIFF
--- a/Packages/User/AngularJS-sublime-package.sublime-settings
+++ b/Packages/User/AngularJS-sublime-package.sublime-settings
@@ -1,3 +1,3 @@
 {
-	"disable_default_element_completions": false
+	"disable_default_element_completions": true,
 }

--- a/Packages/User/CTags.sublime-settings
+++ b/Packages/User/CTags.sublime-settings
@@ -3,15 +3,14 @@
   "command" : "/usr/local/bin/ctags",
   "opts" : [],
   "select_searched_symbol": false,
-  "tag_file": "{$project_path}/.git/tags",
-  "comment123": "Hardcoding 2.7.3 ruby for now",
+  "tag_file": "{$project_path}/.git/tags_sorted_by_file",
+  "comment123": "Hardcoding ruby tag locations for now",
   "extra_tag_paths": [
-      [["source.ruby", "ruby_stdlib_273"], "{$HOME}/.rbenv/versions/2.7.3/include/ruby-2.7.0/tags"],
-      [["source.ruby", "ruby_stdlib_273"], "{$HOME}/.rbenv/versions/2.7.3/lib/ruby/site_ruby/2.7.0/tags"],
-      [["source.ruby", "ruby_stdlib_273"], "{$HOME}/.rbenv/versions/2.7.3/lib/ruby/2.7.0/tags"]
+      [["source.ruby", "ruby_stdlib_273"], "{$HOME}/.rbenv/versions/2.7.3/"],
+      [["source.ruby", "ruby_stdlib_274"], "{$HOME}/.rbenv/versions/2.7.4/"],
+      [["source.ruby", "ruby_stdlib_274"], "{$HOME}/.rbenv/versions/3.0.0/"]
   ],
   "extra_tag_files": [
-    "{$project_path}/.git/gemtags",
-    "{$project_path}/.git/tags_sorted_by_file",
+    "{$project_path}/.git/tags"
   ]
 }

--- a/Packages/User/Preferences.sublime-settings
+++ b/Packages/User/Preferences.sublime-settings
@@ -4,7 +4,15 @@
 		"dialogue",
 		"backend",
 		"api",
-		"Kotlin"
+		"Kotlin",
+		"https",
+		"graphql",
+		"html",
+		"elasticsearch",
+		"bool",
+		"json",
+		"gte",
+		"lte",
 	],
 	"auto_match_enabled": false,
 	"auto_complete_commit_on_tab": true,
@@ -57,7 +65,7 @@
 	[
 		"subpixel_antialias"
 	],
-	"font_size": 12,
+	"font_size": 13,
 	"highlight_modified_tabs": true,
 	"ignored_packages":
 	[

--- a/Packages/User/SublimeLinter.sublime-settings
+++ b/Packages/User/SublimeLinter.sublime-settings
@@ -1,5 +1,10 @@
 // SublimeLinter Settings - User
 {
+  "paths": {
+    "linux": [],
+    "osx": ["~/.rbenv/shims"],
+    "windows": []
+  },
   "lint_mode": "save",
   "delay": 0.25,
   "lint_mode": "save",


### PR DESCRIPTION
- Trying to fix ctag jumping in sublimetext4, turns out the plugin api changed and it is broken...
- Make sublimelinter use rbenv so I can ensure I lint with ruby27 and ruby3
